### PR TITLE
Update 0005_basicstreampage.py

### DIFF
--- a/basic_site/migrations/0005_basicstreampage.py
+++ b/basic_site/migrations/0005_basicstreampage.py
@@ -12,7 +12,7 @@ import basic_site.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
+        ('wagtailcore', '__latest__'),
         ('basic_site', '0004_basicblock_image'),
     ]
 


### PR DESCRIPTION
There was an awkwards bug where depending on the squashed migration failed even when it existed if the database we were doing the migration was below the 0016 migration of wagtail core (wagtail==10b1).
